### PR TITLE
update 2.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.15.1
 #fabric_version=0.89.3+1.20.2
 
 # Mod Properties
-mod_version=1.9.1
+mod_version=2.0.0
 maven_group=smsk.smoothscroll
 archives_base_name=smoothscroll
 

--- a/src/main/java/smsk/smoothscroll/Config.java
+++ b/src/main/java/smsk/smoothscroll/Config.java
@@ -13,7 +13,7 @@ import net.fabricmc.loader.api.FabricLoader;
 
 public class Config {
     public static Cdata cfg;
-    public static float cfgVersion = 1.91f;
+    public static float cfgVersion = 2.0f;
     public static boolean problemReading = false;
 
     public Config() {

--- a/src/main/java/smsk/smoothscroll/SmoothSc.java
+++ b/src/main/java/smsk/smoothscroll/SmoothSc.java
@@ -25,7 +25,7 @@ public class SmoothSc implements ModInitializer {
 	public static int creativeScreenItemCount = 0;
 	public static CreativeScreenHandler creativeSH;
 	public static boolean creativeScreenScrollMixin = true;
-	public static int creativeScreenPredRow = 0;
+	public static int creativeScreenPrevRow = 0;
 	public static int hotbarRollover = 0;
 
 	@Override

--- a/src/main/java/smsk/smoothscroll/SmoothSc.java
+++ b/src/main/java/smsk/smoothscroll/SmoothSc.java
@@ -4,6 +4,7 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.font.TextRenderer.TextLayerType;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen.CreativeScreenHandler;
 import net.minecraft.client.render.RenderLayer;
@@ -11,6 +12,7 @@ import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.text.OrderedText;
 import net.minecraft.util.math.ColorHelper.Argb;
 
+import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +58,15 @@ public class SmoothSc implements ModInitializer {
         drawContext.draw();
         return (a);
     }
+    public static int unmodifiedShadowedText(DrawContext drawContext, TextRenderer textRenderer, @Nullable String text, int x, int y, int color) {
+        if (text == null) {
+            return 0;
+        } else {
+            int i = textRenderer.draw(text, (float)x, (float)y, color, true, drawContext.getMatrices().peek().getPositionMatrix(), drawContext.getVertexConsumers(), TextLayerType.NORMAL, 0, 15728880, textRenderer.isRightToLeft());
+            drawContext.draw();
+            return i;
+        }
+   }
 	public static void unmodifiedFill(DrawContext drawContext, int x1, int y1, int x2, int y2, int color) {
         // this is a workaround because immediately fast scissor doesn't work for fill
         int z = 0;

--- a/src/main/java/smsk/smoothscroll/SmoothSc.java
+++ b/src/main/java/smsk/smoothscroll/SmoothSc.java
@@ -1,6 +1,7 @@
 package smsk.smoothscroll;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
@@ -19,6 +20,8 @@ public class SmoothSc implements ModInitializer {
 	public static final MinecraftClient mc = MinecraftClient.getInstance();
 
 	public static Config cfg;
+    public static boolean isImmediatelyFastLoaded;
+
 	public static int creativeScreenScrollOffset = 0;
 	public static float creativeScreenTargetPos = 0;
 	public static float creativeScreenCurrentPos = 0;
@@ -26,11 +29,14 @@ public class SmoothSc implements ModInitializer {
 	public static CreativeScreenHandler creativeSH;
 	public static boolean creativeScreenScrollMixin = true;
 	public static int creativeScreenPrevRow = 0;
+
 	public static int hotbarRollover = 0;
+
 
 	@Override
 	public void onInitialize() {
 		updateConfig();
+        isImmediatelyFastLoaded = FabricLoader.getInstance().isModLoaded("immediatelyfast");
 	}
 
 	public static void print(Object s) {

--- a/src/main/java/smsk/smoothscroll/mixin/Chat/ChatHudMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/Chat/ChatHudMixin.java
@@ -97,7 +97,16 @@ public class ChatHudMixin {
         var masktop = m - maskHeightBuffer + (int) mtc.y;
         var maskbottom = m + (int) mtc.y;
 
-        //currentContext.fill(0, m-targetHeight, 2, maskbottom, ColorHelper.Argb.getArgb(50, 255, 255, 0));
+        // this makes underlined text and such correct again
+        if (scrollOffset == 0 && maskHeightBuffer != 0) {
+            if (maskHeightBuffer == targetHeight) {
+                maskbottom += 2;
+                masktop -= 2;
+            } else {
+                maskbottom += 2;
+            }
+        }
+
         savedContext.enableScissor(0, masktop, savedContext.getScaledWindowWidth(), maskbottom);
         return (m);
     }

--- a/src/main/java/smsk/smoothscroll/mixin/Chat/ChatHudMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/Chat/ChatHudMixin.java
@@ -126,7 +126,7 @@ public class ChatHudMixin {
     @ModifyVariable(method = "render", at = @At("STORE"))
     private long demask(long a) { // after the cycle
         if (Config.cfg.chatSpeed == 0 || this.isChatHidden()) return (a);
-        if (Config.cfg.enableMaskDebug) savedContext.fill(-100, -100, savedContext.getScaledWindowWidth(), savedContext.getScaledWindowHeight(), ColorHelper.Argb.getArgb(50, 255, 0, 255));
+        if (Config.cfg.enableMaskDebug) SmoothSc.unmodifiedFill(savedContext, -100, -100, savedContext.getScaledWindowWidth(), savedContext.getScaledWindowHeight(), ColorHelper.Argb.getArgb(50, 255, 0, 255));
         savedContext.disableScissor();
         return (a);
     }

--- a/src/main/java/smsk/smoothscroll/mixin/Chat/ChatHudMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/Chat/ChatHudMixin.java
@@ -73,9 +73,9 @@ public class ChatHudMixin {
         if ((Config.cfg.chatSpeed == 0 && Config.cfg.chatOpeningSpeed == 0) || isChatHidden()) return (m);
 
         var shownLineCount = 0;
-        SmoothSc.print("1: "+visibleMessages.size());
+        //SmoothSc.print("1: "+visibleMessages.size());
         for(int r = 0; r + scrolledLines < visibleMessages.size() && r < getVisibleLineCount(); r++) {
-            SmoothSc.print("2: "+(savedCurrentTick - visibleMessages.get(r).addedTime()));
+            //SmoothSc.print("2: "+(savedCurrentTick - visibleMessages.get(r).addedTime()));
             if (savedCurrentTick - visibleMessages.get(r).addedTime() < 200 || isChatFocused()) shownLineCount++;
         }
         // var targetHeight = getVisibleLineCount() * getLineHeight();

--- a/src/main/java/smsk/smoothscroll/mixin/Chat/ChatHudMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/Chat/ChatHudMixin.java
@@ -73,7 +73,9 @@ public class ChatHudMixin {
         if ((Config.cfg.chatSpeed == 0 && Config.cfg.chatOpeningSpeed == 0) || isChatHidden()) return (m);
 
         var shownLineCount = 0;
+        SmoothSc.print("1: "+visibleMessages.size());
         for(int r = 0; r + scrolledLines < visibleMessages.size() && r < getVisibleLineCount(); r++) {
+            SmoothSc.print("2: "+(savedCurrentTick - visibleMessages.get(r).addedTime()));
             if (savedCurrentTick - visibleMessages.get(r).addedTime() < 200 || isChatFocused()) shownLineCount++;
         }
         // var targetHeight = getVisibleLineCount() * getLineHeight();

--- a/src/main/java/smsk/smoothscroll/mixin/Chat/SuggestionWindowMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/Chat/SuggestionWindowMixin.java
@@ -8,14 +8,17 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.mojang.brigadier.suggestion.Suggestion;
 
+import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ChatInputSuggestor.SuggestionWindow;
 import net.minecraft.client.util.math.Rect2i;
+import net.minecraft.text.OrderedText;
 import net.minecraft.util.math.ColorHelper;
 import smsk.smoothscroll.Config;
 import smsk.smoothscroll.SmoothSc;
@@ -82,5 +85,14 @@ public class SuggestionWindowMixin {
     private int addLineUnder(int i) {
         if (Config.cfg.chatSpeed == 0 || scrollPixelOffset >= 0 || inWindowIndex >= suggestions.size() - 10) return (i);
         return (i + 1);
+    }
+
+    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTextWithShadow(Lnet/minecraft/client/font/TextRenderer;Ljava/lang/String;III)I"))
+    private int unmodifiedShadowedText(DrawContext drawContext, TextRenderer textRenderer, OrderedText text, int x, int y, int color) {
+        return (SmoothSc.unmodifiedShadowedText(drawContext, textRenderer, text, x, y, color));
+    }
+    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;fill(IIIII)V"))
+    private void unmodifiedFill(DrawContext drawContext, int x1, int y1, int x2, int y2, int color) {
+        SmoothSc.unmodifiedFill(drawContext, x1, y1, x2, y2, color);
     }
 }

--- a/src/main/java/smsk/smoothscroll/mixin/Chat/SuggestionWindowMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/Chat/SuggestionWindowMixin.java
@@ -2,6 +2,7 @@ package smsk.smoothscroll.mixin.Chat;
 
 import java.util.List;
 
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -18,7 +19,6 @@ import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ChatInputSuggestor.SuggestionWindow;
 import net.minecraft.client.util.math.Rect2i;
-import net.minecraft.text.OrderedText;
 import net.minecraft.util.math.ColorHelper;
 import smsk.smoothscroll.Config;
 import smsk.smoothscroll.SmoothSc;
@@ -28,6 +28,7 @@ public class SuggestionWindowMixin {
     @Shadow int inWindowIndex;
     @Shadow List<Suggestion> suggestions;
     @Shadow Rect2i area;
+    DrawContext savedContext;
     int indexBefore;
     int scrollPixelOffset;
     int targetIndex;
@@ -35,21 +36,35 @@ public class SuggestionWindowMixin {
 
     @Inject(method = "render", at = @At("HEAD"))
     private void renderH(DrawContext context, int mouseX, int mouseY, CallbackInfo ci) {
+        savedContext = context;
         lFDBuffer += SmoothSc.mc.getLastFrameDuration();
         var a = scrollPixelOffset;
         scrollPixelOffset = (int) Math.round(scrollPixelOffset * Math.pow(Config.cfg.chatSpeed, lFDBuffer));
         if (a != scrollPixelOffset || scrollPixelOffset == 0) lFDBuffer = 0;
-
         inWindowIndex = SmoothSc.clamp(targetIndex - scrollPixelOffset / 12, 0, suggestions.size() - 10); // the clamp is here as a workaround to a crash
-        context.enableScissor(area.getX() - 1, area.getY() - 1, area.getX() + area.getWidth() + 1, area.getY() + area.getHeight() + 1);
+    }
+    /*@ModifyVariable(method = "render", at = @At(value = "STORE"), ordinal = 4) idk why this doesn't work
+    private boolean mask(boolean a) {
+        SmoothSc.print(a);
+        savedContext.enableScissor(area.getX() - 1, area.getY(), area.getX() + area.getWidth() + 1, area.getY() + area.getHeight());
+        return (a);
+    }/* */
+
+    @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;fill(IIIII)V", ordinal = 4))
+    private void mask(DrawContext context, int mouseX, int mouseY, CallbackInfo ci) {
+        savedContext.enableScissor(area.getX() - 1, area.getY(), area.getX() + area.getWidth() + 1, area.getY() + area.getHeight());
+    }
+
+    @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTextWithShadow(Lnet/minecraft/client/font/TextRenderer;Ljava/lang/String;III)I", shift = At.Shift.AFTER))
+    private void demask(DrawContext context, int mouseX, int mouseY, CallbackInfo ci) {
+        if (Config.cfg.enableMaskDebug)
+            SmoothSc.unmodifiedFill(context, -100, -100, context.getScaledWindowWidth(), context.getScaledWindowHeight(), ColorHelper.Argb.getArgb(50, 255, 255, 0));
+        context.disableScissor();
     }
 
     @Inject(method = "render", at = @At("TAIL"))
     private void renderT(DrawContext context, int mouseX, int mouseY, CallbackInfo ci) {
         inWindowIndex = targetIndex;
-        if (Config.cfg.enableMaskDebug)
-            context.fill(-100, -100, context.getScaledWindowWidth(), context.getScaledWindowHeight(), ColorHelper.Argb.getArgb(50, 255, 255, 0));
-        context.disableScissor();
     }
 
     @ModifyArg(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTextWithShadow(Lnet/minecraft/client/font/TextRenderer;Ljava/lang/String;III)I"), index = 3)
@@ -88,7 +103,7 @@ public class SuggestionWindowMixin {
     }
 
     @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTextWithShadow(Lnet/minecraft/client/font/TextRenderer;Ljava/lang/String;III)I"))
-    private int unmodifiedShadowedText(DrawContext drawContext, TextRenderer textRenderer, OrderedText text, int x, int y, int color) {
+    private int unmodifiedShadowedText(DrawContext drawContext, TextRenderer textRenderer, @Nullable String text, int x, int y, int color) {
         return (SmoothSc.unmodifiedShadowedText(drawContext, textRenderer, text, x, y, color));
     }
     @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;fill(IIIII)V"))

--- a/src/main/java/smsk/smoothscroll/mixin/CreativeScreen/CreativeScreenHandlerMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/CreativeScreen/CreativeScreenHandlerMixin.java
@@ -19,8 +19,8 @@ public class CreativeScreenHandlerMixin {
         SmoothSc.creativeScreenItemCount = 0;
         if (!SmoothSc.creativeScreenScrollMixin) return (row);
         
-        SmoothSc.creativeScreenScrollOffset += 18 * (row - SmoothSc.creativeScreenPredRow);
-        SmoothSc.creativeScreenPredRow = row;
+        SmoothSc.creativeScreenScrollOffset += 18 * (row - SmoothSc.creativeScreenPrevRow);
+        SmoothSc.creativeScreenPrevRow = row;
         return (row);
     }
 

--- a/src/main/java/smsk/smoothscroll/mixin/CreativeScreen/CreativeScreenMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/CreativeScreen/CreativeScreenMixin.java
@@ -47,7 +47,7 @@ public class CreativeScreenMixin {
                 x2, y2, x1, y1);
 
         if (Config.cfg.enableMaskDebug)
-            context.fill(-100, -100, context.getScaledWindowWidth(), context.getScaledWindowHeight(), ColorHelper.Argb.getArgb(50, 255, 255, 0));
+            SmoothSc.unmodifiedFill(context, -100, -100, context.getScaledWindowWidth(), context.getScaledWindowHeight(), ColorHelper.Argb.getArgb(50, 255, 255, 0));
         
         context.disableScissor();
     }

--- a/src/main/java/smsk/smoothscroll/mixin/CreativeScreen/HandledScreenMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/CreativeScreen/HandledScreenMixin.java
@@ -3,7 +3,7 @@ package smsk.smoothscroll.mixin.CreativeScreen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
@@ -17,8 +17,8 @@ import smsk.smoothscroll.SmoothSc;
 @Mixin(HandledScreen.class)
 public class HandledScreenMixin {
 
-    Identifier backtex = new Identifier("textures/gui/container/creative_inventory/tab_items");
-    boolean cutenabled = false;
+    Identifier backTex = new Identifier("textures/gui/container/creative_inventory/tab_items");
+    boolean cutEnabled = false;
     float lFDBuffer;
 
     @Inject(method = "render", at = @At("HEAD"))
@@ -32,30 +32,40 @@ public class HandledScreenMixin {
 
         SmoothSc.creativeScreenScrollMixin = false;
         SmoothSc.creativeSH.scrollItems(((CreativeScreenHandlerAccessor) SmoothSc.creativeSH)
-                .getPos(SmoothSc.creativeScreenPredRow - SmoothSc.creativeScreenScrollOffset / 18));
+                .getPos(SmoothSc.creativeScreenPrevRow - SmoothSc.creativeScreenScrollOffset / 18));
         SmoothSc.creativeScreenScrollMixin = true;
-    }
-
-    @ModifyArg(method = "drawSlot", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawItem(Lnet/minecraft/item/ItemStack;III)V"), index = 2)
-    int drawItemY(int y) {
-        if (Config.cfg.creativeScreenSpeed == 0 || SmoothSc.creativeScreenItemCount <= 0) return (y);
-        SmoothSc.creativeScreenItemCount -= 1;
-        return (y + SmoothSc.creativeScreenScrollOffset - SmoothSc.creativeScreenScrollOffset / 18 * 18);
     }
 
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;drawSlot(Lnet/minecraft/client/gui/DrawContext;Lnet/minecraft/screen/slot/Slot;)V"))
     void renderMid0(DrawContext context, int mx, int my, float d, CallbackInfo ci) {
         if (Config.cfg.creativeScreenSpeed == 0 || SmoothSc.creativeScreenItemCount <= 0 || SmoothSc.creativeScreenScrollOffset == 0) return;
         context.enableScissor(0, context.getScaledWindowHeight() / 2 - 50, context.getScaledWindowWidth(), context.getScaledWindowHeight() / 2 + 38);
-        cutenabled = true;
+        cutEnabled = true;
+
+        // the fix for instantly disappearing items on the opposite side of scrolling...
+        // it gets the items that just left the slots and draws them in the correct
+        // position
+        var overUnder = SmoothSc.creativeScreenScrollOffset < 0 ? 9 * 5 : -9;
+        var currRow = SmoothSc.creativeScreenPrevRow - SmoothSc.creativeScreenScrollOffset / 18;
+        var fromIndex = currRow * 9 + overUnder;
+        for(int i = fromIndex; i >= 0 && i < SmoothSc.creativeSH.itemList.size() && i < fromIndex + 9; i++) {
+            context.drawItem(SmoothSc.creativeSH.itemList.get(i), 9 + i % 9 * 18, currRow + (SmoothSc.creativeScreenScrollOffset > 0 ? 0 : 18 * 6));
+        }
+    }
+
+    @ModifyVariable(method = "drawSlot", at = @At(value = "STORE"), ordinal = 1)
+    int drawItemY(int y) {
+        if (Config.cfg.creativeScreenSpeed == 0 || SmoothSc.creativeScreenItemCount <= 0) return (y);
+        SmoothSc.creativeScreenItemCount -= 1;
+        return (y + SmoothSc.creativeScreenScrollOffset - SmoothSc.creativeScreenScrollOffset / 18 * 18);
     }
 
     @Inject(method = "render", at = @At(shift = Shift.AFTER, value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;drawSlot(Lnet/minecraft/client/gui/DrawContext;Lnet/minecraft/screen/slot/Slot;)V"))
     void renderMid1(DrawContext context, int mx, int my, float d, CallbackInfo ci) {
-        if (!cutenabled) return;
+        if (!cutEnabled) return;
         if (Config.cfg.enableMaskDebug)
             context.fill(-100, -100, context.getScaledWindowWidth(), context.getScaledWindowHeight(), ColorHelper.Argb.getArgb(50, 0, 255, 255));
         context.disableScissor();
-        cutenabled = false;
+        cutEnabled = false;
     }
 }

--- a/src/main/java/smsk/smoothscroll/mixin/CreativeScreen/HandledScreenMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/CreativeScreen/HandledScreenMixin.java
@@ -49,7 +49,7 @@ public class HandledScreenMixin {
         var currRow = SmoothSc.creativeScreenPrevRow - SmoothSc.creativeScreenScrollOffset / 18;
         var fromIndex = currRow * 9 + overUnder;
         for(int i = fromIndex; i >= 0 && i < SmoothSc.creativeSH.itemList.size() && i < fromIndex + 9; i++) {
-            context.drawItem(SmoothSc.creativeSH.itemList.get(i), 9 + i % 9 * 18, currRow + (SmoothSc.creativeScreenScrollOffset > 0 ? 0 : 18 * 6));
+            context.drawItem(SmoothSc.creativeSH.itemList.get(i), 9 + i % 9 * 18, SmoothSc.creativeScreenScrollOffset - SmoothSc.creativeScreenScrollOffset / 18 * 18 + (SmoothSc.creativeScreenScrollOffset > 0 ? 0 : 18 * 6));
         }
     }
 

--- a/src/main/java/smsk/smoothscroll/mixin/CreativeScreen/HandledScreenMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/CreativeScreen/HandledScreenMixin.java
@@ -64,7 +64,7 @@ public class HandledScreenMixin {
     void renderMid1(DrawContext context, int mx, int my, float d, CallbackInfo ci) {
         if (!cutEnabled) return;
         if (Config.cfg.enableMaskDebug)
-            context.fill(-100, -100, context.getScaledWindowWidth(), context.getScaledWindowHeight(), ColorHelper.Argb.getArgb(50, 0, 255, 255));
+            SmoothSc.unmodifiedFill(context, -100, -100, context.getScaledWindowWidth(), context.getScaledWindowHeight(), ColorHelper.Argb.getArgb(50, 0, 255, 255));
         context.disableScissor();
         cutEnabled = false;
     }

--- a/src/main/java/smsk/smoothscroll/mixin/Hotbar/HotbarMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/Hotbar/HotbarMixin.java
@@ -60,11 +60,12 @@ public class HotbarMixin {
 		x += selectedPixelBuffer;
 		masked = true;
 		args.set(1, x);
-
-		if (selectedPixelBuffer < 0){
-			savedContext.drawGuiTexture(texture, x + 9 * 20, y, width, height);
-		} else if (selectedPixelBuffer > 20 * 8) {
-			savedContext.drawGuiTexture(texture, x - 9 * 20, y, width, height);
+		if (!SmoothSc.isImmediatelyFastLoaded) {
+			if (selectedPixelBuffer < 0) {
+				savedContext.drawGuiTexture(texture, x + 9 * 20, y, width, height);
+			} else if (selectedPixelBuffer > 20 * 8) {
+				savedContext.drawGuiTexture(texture, x - 9 * 20, y, width, height);
+			}
 		}
 	}
 

--- a/src/main/java/smsk/smoothscroll/mixin/Hotbar/HotbarMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/Hotbar/HotbarMixin.java
@@ -72,7 +72,7 @@ public class HotbarMixin {
 	@Inject(method = "renderHotbar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Lnet/minecraft/util/Identifier;IIII)V", ordinal = 1, shift = At.Shift.AFTER))
 	private void draw2(float tickDelta, DrawContext context, CallbackInfo ci) {
 		if (!masked) return;
-        if (Config.cfg.enableMaskDebug) savedContext.fill(-100, -100, savedContext.getScaledWindowWidth(), savedContext.getScaledWindowHeight(), ColorHelper.Argb.getArgb(50, 0, 255, 255));
+        if (Config.cfg.enableMaskDebug) SmoothSc.unmodifiedFill(savedContext, -100, -100, savedContext.getScaledWindowWidth(), savedContext.getScaledWindowHeight(), ColorHelper.Argb.getArgb(50, 0, 255, 255));
 		context.disableScissor();
 	}
 }

--- a/src/main/java/smsk/smoothscroll/mixin/Hotbar/HotbarMixin.java
+++ b/src/main/java/smsk/smoothscroll/mixin/Hotbar/HotbarMixin.java
@@ -2,10 +2,16 @@ package smsk.smoothscroll.mixin.Hotbar;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
+import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.ColorHelper;
 import smsk.smoothscroll.Config;
 import smsk.smoothscroll.SmoothSc;
 
@@ -14,16 +20,33 @@ public class HotbarMixin {
 
 	int selectedPixelBuffer = 0;
 	float lFDBuffer;
+	boolean masked = false;
+	DrawContext savedContext;
 
-	@ModifyArg(method = "renderHotbar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Lnet/minecraft/util/Identifier;IIII)V", ordinal = 1), index = 1)
-	private int selectedSlotX(int x) {
-		if (Config.cfg.hotbarSpeed == 0) return (x);
+	@Inject(method = "renderHotbar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Lnet/minecraft/util/Identifier;IIII)V", ordinal = 1))
+	private void draw1(float tickDelta, DrawContext context, CallbackInfo ci) {
+		if (Config.cfg.hotbarSpeed == 0) return;
+		var x = context.getScaledWindowWidth() / 2 - 91;
+		var y = context.getScaledWindowHeight() - 22;
+		context.enableScissor(x - 1, y - 1, x + 182 + 1, y + 22 + 1);
+		savedContext = context;
+	}
+
+	@ModifyArgs(method = "renderHotbar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Lnet/minecraft/util/Identifier;IIII)V", ordinal = 1))
+	private void selectedSlotX(Args args) {
+		if (Config.cfg.hotbarSpeed == 0) return;
+		Identifier texture = args.get(0);
+		int x = args.get(1);
+		int y = args.get(2);
+		int width = args.get(3);
+		int height = args.get(4);
 		PlayerInventory inv = SmoothSc.mc.player.getInventory();
 
 		lFDBuffer += SmoothSc.mc.getLastFrameDuration();
 		var a = selectedPixelBuffer;
-		selectedPixelBuffer = (int) Math.round((selectedPixelBuffer - (inv.selectedSlot - SmoothSc.hotbarRollover * 9) * 20) * Math.pow(Config.cfg.hotbarSpeed, lFDBuffer) + (inv.selectedSlot - SmoothSc.hotbarRollover * 9) * 20);
-		if (selectedPixelBuffer != a || selectedPixelBuffer == inv.selectedSlot * 20) lFDBuffer = 0;
+		var target = (inv.selectedSlot - SmoothSc.hotbarRollover * 9) * 20;
+		selectedPixelBuffer = (int) Math.round((selectedPixelBuffer - target) * Math.pow(Config.cfg.hotbarSpeed, lFDBuffer) + target);
+		if (selectedPixelBuffer != a || selectedPixelBuffer == target) lFDBuffer = 0;
 		
 		if (selectedPixelBuffer < -10) {
 			selectedPixelBuffer += 9 * 20;
@@ -35,6 +58,20 @@ public class HotbarMixin {
 
 		x -= inv.selectedSlot * 20;
 		x += selectedPixelBuffer;
-		return (x);
+		masked = true;
+		args.set(1, x);
+
+		if (selectedPixelBuffer < 0){
+			savedContext.drawGuiTexture(texture, x + 9 * 20, y, width, height);
+		} else if (selectedPixelBuffer > 20 * 8) {
+			savedContext.drawGuiTexture(texture, x - 9 * 20, y, width, height);
+		}
+	}
+
+	@Inject(method = "renderHotbar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Lnet/minecraft/util/Identifier;IIII)V", ordinal = 1, shift = At.Shift.AFTER))
+	private void draw2(float tickDelta, DrawContext context, CallbackInfo ci) {
+		if (!masked) return;
+        if (Config.cfg.enableMaskDebug) savedContext.fill(-100, -100, savedContext.getScaledWindowWidth(), savedContext.getScaledWindowHeight(), ColorHelper.Argb.getArgb(50, 0, 255, 255));
+		context.disableScissor();
 	}
 }


### PR DESCRIPTION
- Chat mask now no longer masks underlines and other similar stuff when possible
- Suggestion window now uses unmodified fill and text, so immediately fast doesn't break the masking
- Hotbar scrolling is now perfectly scrolling (only if you don't have immediately fast installed)
- Creative screen is now perfectly scrolling
- Mask debug fills now also use the unmodified fill