### PR TITLE
feat: disable the built-in smooth scrolling feature in Jade (close #81)

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,9 +18,9 @@
 		"client": [
 			"smsk.smoothscroll.SmoothSc"
 		],
-        "modmenu": [
-            "smsk.smoothscroll.menu.ModMenuImpl"
-        ]
+		"modmenu": [
+			"smsk.smoothscroll.menu.ModMenuImpl"
+		]
 	},
 	"mixins": [
 		"smoothscroll.mixins.json"
@@ -30,7 +30,9 @@
 		"minecraft": ">=1.21.9",
 		"java": ">=21"
 	},
-	"suggests": {
-		"another-mod": "*"
+	"custom": {
+		"jade": {
+			"smoothScroll": true
+		}
 	}
 }


### PR DESCRIPTION
Only works on 1.21.11+. No need to backport.