### PR TITLE
fix: resolve missing slot highlights in non-creative inventories

### DIFF
--- a/src/client/java/io/github/smajloslovakian/smoothscroll/duck/CreativeModeInventoryScreenDuck.java
+++ b/src/client/java/io/github/smajloslovakian/smoothscroll/duck/CreativeModeInventoryScreenDuck.java
@@ -6,4 +6,5 @@ public interface CreativeModeInventoryScreenDuck {
     void enMask(GuiGraphicsExtractor graphics);
     void deMask(GuiGraphicsExtractor graphics);
     boolean isMouseInbounds();
+    boolean canScroll();
 }

--- a/src/client/java/io/github/smajloslovakian/smoothscroll/mixin/client/CreativeScreen/AbstractContainerScreenMixin.java
+++ b/src/client/java/io/github/smajloslovakian/smoothscroll/mixin/client/CreativeScreen/AbstractContainerScreenMixin.java
@@ -14,12 +14,9 @@ public class AbstractContainerScreenMixin {
 
     @WrapMethod(method = "extractSlotHighlightBack")
     private void extractSlotHighlightBackWrap(GuiGraphicsExtractor graphics, Operation<Void> operation) {
-        if (this instanceof CreativeModeInventoryScreenDuck a) {
-            if (!a.isMouseInbounds()) {
-                operation.call(graphics);
-                return;
-            }
+        if (this instanceof CreativeModeInventoryScreenDuck a && a.isMouseInbounds() && a.canScroll()) {
             a.enMask(graphics);
+            operation.call(graphics);
             a.deMask(graphics);
         } else {
             operation.call(graphics);
@@ -28,11 +25,7 @@ public class AbstractContainerScreenMixin {
 
     @WrapMethod(method = "extractSlotHighlightFront")
     private void extractSlotHighlightFrontWrap(GuiGraphicsExtractor graphics, Operation<Void> operation) {
-        if (this instanceof CreativeModeInventoryScreenDuck a) {
-            if (!a.isMouseInbounds()) {
-                operation.call(graphics);
-                return;
-            }
+        if (this instanceof CreativeModeInventoryScreenDuck a && a.isMouseInbounds() && a.canScroll()) {
             a.enMask(graphics);
             operation.call(graphics);
             a.deMask(graphics);

--- a/src/client/java/io/github/smajloslovakian/smoothscroll/mixin/client/CreativeScreen/CreativeModeInventoryScreenMixin.java
+++ b/src/client/java/io/github/smajloslovakian/smoothscroll/mixin/client/CreativeScreen/CreativeModeInventoryScreenMixin.java
@@ -28,7 +28,7 @@ import io.github.smajloslovakian.smoothscroll.SmoothSc;
 import io.github.smajloslovakian.smoothscroll.cfg.SmScCfg;
 import io.github.smajloslovakian.smoothscroll.duck.CreativeModeInventoryScreenDuck;
 
-// TODO check compatibility with: item borders, flow, item highlighter, bedrockify
+// TODO check compatibility with: item borders, flow, bedrockify
 
 @Mixin(value = CreativeModeInventoryScreen.class)
 public abstract class CreativeModeInventoryScreenMixin extends AbstractContainerScreen<ItemPickerMenu> implements CreativeModeInventoryScreenDuck {
@@ -219,6 +219,10 @@ public abstract class CreativeModeInventoryScreenMixin extends AbstractContainer
     @Override
     public boolean isMouseInbounds() {
         return mouseInBounds;
+    }
+    @Override
+    public boolean canScroll() {
+        return selectedTab.canScroll();
     }
 
     public CreativeModeInventoryScreenMixin(ItemPickerMenu menu, Inventory inventory, Component title) {


### PR DESCRIPTION
This pull request updates the handling of slot highlighting in creative inventory screens by adding a new scrollability check and refactoring related logic. The main focus is to ensure that masking for slot highlights only occurs when both the mouse is in bounds and scrolling is allowed, improving UI behavior and compatibility.

**Creative screen scrollability and slot highlight logic:**

* Added a new method `canScroll()` to the `CreativeModeInventoryScreenDuck` interface, and implemented it in `CreativeModeInventoryScreenMixin` to delegate to `selectedTab.canScroll()`. [[1]](diffhunk://#diff-6f6022ca7d831d8ff28318f50a6280b2f0e623e32dac5039d4118657d6818182R9) [[2]](diffhunk://#diff-41761c662288995025d49127df05c5b37ed9a5b81db2d98f4bc5a3c0e3457b14R223-R226)
* Updated the logic in both `extractSlotHighlightBackWrap` and `extractSlotHighlightFrontWrap` to require both `isMouseInbounds()` and `canScroll()` before applying masking, simplifying the conditional and ensuring correct highlight behavior. [[1]](diffhunk://#diff-5b97ebec37b7988e09010cd66d6da3ce4495f1f7a617daff06b907db36ecf0efL17-R19) [[2]](diffhunk://#diff-5b97ebec37b7988e09010cd66d6da3ce4495f1f7a617daff06b907db36ecf0efL31-R28)

**Other things:**
 * Updated a TODO comment to remove "item highlighter" from the compatibility checklist, reflecting current compatibility status.
 * This also fixed a bug where you could "half select" armor slots in the creative inventory